### PR TITLE
Update for RGBWW (RGB+CCT) protocol

### DIFF
--- a/MiLightRadio.cpp
+++ b/MiLightRadio.cpp
@@ -9,7 +9,7 @@
 
 #define PACKET_ID(packet) ( ((packet[1] & 0xF0)<<24) | (packet[2]<<16) | (packet[3]<<8) | (packet[7]) )
 
-static const uint8_t CHANNELS[] = {9, 40, 71};
+static const uint8_t CHANNELS[] = {70, 39, 8};
 #define NUM_CHANNELS (sizeof(CHANNELS)/sizeof(CHANNELS[0]))
 
 MiLightRadio::MiLightRadio(AbstractPL1167 &pl1167)
@@ -39,12 +39,12 @@ int MiLightRadio::begin()
     return retval;
   }
 
-  retval = _pl1167.setSyncword(0x147A, 0x258B);
+  retval = _pl1167.setSyncword(0x7236, 0x1809);
   if (retval < 0) {
     return retval;
   }
 
-  retval = _pl1167.setMaxPacketLength(8);
+  retval = _pl1167.setMaxPacketLength(10);
   if (retval < 0) {
     return retval;
   }

--- a/MiLightRadio.h
+++ b/MiLightRadio.h
@@ -31,7 +31,7 @@ class MiLightRadio {
     AbstractPL1167 &_pl1167;
     uint32_t _prev_packet_id;
 
-    uint8_t _packet[8], _out_packet[8];
+    uint8_t _packet[10], _out_packet[10];
     bool _waiting;
     int _dupes_received;
 };


### PR DESCRIPTION
Here are the changes to channels, syncwords and packet length that would be necessary to support the new milight bulbs. It doesn't really make sense to merge this directly since it would break support for the older bulbs, but I figured I would put it here in case anyone wants to base work off the changes. 

I've used this code to inspect packets coming from the new bulbs with an Arduino. It does nothing about the [new scrambled protocol](http://www.authometion.com/forum/viewtopic.php?t=639), but it's a good place to start.